### PR TITLE
Looking in all file types for new keys

### DIFF
--- a/bin/scripts.js
+++ b/bin/scripts.js
@@ -156,7 +156,7 @@ function unzipTranslations(callback) {
 
 function scanDirectory(directory, fileName, callback) {
 	logger.debug("Scaning " + directory + " for keys.");
-	exec('find ' + directory + ' -iname "*.js" | xargs xgettext -j --from-code=UTF-8 --force-po --no-wrap -ktr:1 -ktrd:1 -ktrn:1,2 -ktrnd:1,2 -o i18n/' + fileName + ' -LJavaScript',
+	exec('find ' + directory + ' -iname "*.*" | xargs xgettext -j --from-code=UTF-8 --force-po --no-wrap -ktr:1 -ktrd:1 -ktrn:1,2 -ktrnd:1,2 -o i18n/' + fileName + ' -LJavaScript',
 		function(error) {
 			if (error !== null) {
 				logger.warn("Error scaning directory " + directory);


### PR DESCRIPTION
This change is necessary becase i'm using this library with typescript in another project, so the file extension is not `.js`, but it is `.ts`.

With another alternative for that, we can do something like [this](https://github.com/mercadolibre/frontend-i18n/blob/master/src/m10e.js#L291), but i'm not sure if this is really necessary.. What do you think?